### PR TITLE
mlz tilt reg

### DIFF
--- a/phaser/engines/common/output.py
+++ b/phaser/engines/common/output.py
@@ -185,9 +185,9 @@ def _plot_scan(state: ReconsState, out_path: Path, options: SaveOptions):
     ax.set_xlim(l, r)
     ax.set_ylim(b, t)
 
-    scan = to_numpy(state.scan)
+    scan = to_numpy(state.scan).reshape(-1, 2)
     i = numpy.arange(scan[..., 0].size)
-    ax.scatter(scan[..., 1].ravel(), scan[..., 0].ravel(), c=i, s=0.2, cmap='plasma')
+    ax.scatter(scan[..., 1], scan[..., 0], c=i, s=0.2, cmap='plasma')
 
     fig.savefig(out_path)
     pyplot.close(fig)
@@ -203,12 +203,12 @@ def _plot_tilt(state: ReconsState, out_path: Path, options: SaveOptions):
     ax.set_xlim(l, r)
     ax.set_ylim(b, t)
 
-    scan = to_numpy(state.scan)
-    tilt = to_numpy(state.tilt)
+    scan = to_numpy(state.scan).reshape(-1, 2)
+    tilt = to_numpy(state.tilt).reshape(-1, 2)
     tilt = tilt[..., 1] + tilt[..., 0]*1.j
     max_tilt = max(numpy.max(numpy.abs(tilt)), 1.0)  # at least 1 mrad
     c = colorize_complex(tilt / max_tilt, amp=True, rescale=False)
-    ax.scatter(scan[..., 1].ravel(), scan[..., 0].ravel(), c=c, s=0.2)
+    ax.scatter(scan[..., 1], scan[..., 0], c=c, s=0.2)
 
     fig.draw_without_rendering()
     trans = ax.transAxes + fig.transFigure.inverted()

--- a/phaser/engines/gradient/run.py
+++ b/phaser/engines/gradient/run.py
@@ -421,18 +421,15 @@ def run_model(
     model_wave = fft2(slice_forwards(t_props, probes, sim_slice))
     model_intensity = xp.sum(abs2(model_wave), axis=1)
 
-    cat_loss = []
     (loss, solver_states.noise_model_state) = noise_model.calc_loss(
         model_wave, model_intensity, group_patterns, pattern_mask, solver_states.noise_model_state
     )
 
-    cat_loss.append(loss)
     for (reg_i, reg) in enumerate(regularizers):
         (reg_loss, solver_states.regularizer_states[reg_i]) = reg.calc_loss_group(
             group, sim, solver_states.regularizer_states[reg_i]
         )
         loss += reg_loss
-        cat_loss.append(reg_loss)
     return (loss, solver_states)
 
 

--- a/phaser/engines/gradient/run.py
+++ b/phaser/engines/gradient/run.py
@@ -421,16 +421,18 @@ def run_model(
     model_wave = fft2(slice_forwards(t_props, probes, sim_slice))
     model_intensity = xp.sum(abs2(model_wave), axis=1)
 
+    cat_loss = []
     (loss, solver_states.noise_model_state) = noise_model.calc_loss(
         model_wave, model_intensity, group_patterns, pattern_mask, solver_states.noise_model_state
     )
 
+    cat_loss.append(loss)
     for (reg_i, reg) in enumerate(regularizers):
         (reg_loss, solver_states.regularizer_states[reg_i]) = reg.calc_loss_group(
             group, sim, solver_states.regularizer_states[reg_i]
         )
         loss += reg_loss
-
+        cat_loss.append(reg_loss)
     return (loss, solver_states)
 
 

--- a/phaser/hooks/preprocessing.py
+++ b/phaser/hooks/preprocessing.py
@@ -93,9 +93,9 @@ def drop_nan_patterns(args: PostInitArgs, props: DropNanProps) -> t.Tuple[Patter
             raise ValueError(f"# of tilt positions {tilt.shape[0]} doesn't match # of patterns"
                              f" before ({mask.size}) or after ({patterns.shape[0]}) filtering")
 
-    args['state'].scan = scan
-    args['state'].tilt = tilt
-    args['data'].patterns = patterns
+        args['state'].scan = scan
+        args['state'].tilt = tilt
+        args['data'].patterns = patterns
 
     return (args['data'], args['state'])
 

--- a/phaser/hooks/preprocessing.py
+++ b/phaser/hooks/preprocessing.py
@@ -93,9 +93,9 @@ def drop_nan_patterns(args: PostInitArgs, props: DropNanProps) -> t.Tuple[Patter
             raise ValueError(f"# of tilt positions {tilt.shape[0]} doesn't match # of patterns"
                              f" before ({mask.size}) or after ({patterns.shape[0]}) filtering")
 
-        args['state'].scan = scan
-        args['state'].tilt = tilt
-        args['data'].patterns = patterns
+    args['state'].scan = scan
+    args['state'].tilt = tilt
+    args['data'].patterns = patterns
 
     return (args['data'], args['state'])
 

--- a/phaser/hooks/regularization.py
+++ b/phaser/hooks/regularization.py
@@ -44,6 +44,11 @@ class RegularizeLayersProps(Dataclass):
     sigma: float = 50.0  # standard deviation of gaussian filter (angstrom)
 
 
+class RegularizeTiltProps(Dataclass):
+    weight: float = 0.9  # weight of regularization to apply
+    sigma: float = 50.0  # standard deviation of gaussian filter (angstrom)
+
+
 class ObjLowPassProps(Dataclass):
     max_freq: float = 0.4  # 1/px (nyquist = 0.5)
 
@@ -58,6 +63,7 @@ class IterConstraintHook(Hook[None, IterConstraint]):
         'clamp_object_amplitude': ('phaser.engines.common.regularizers:ClampObjectAmplitude', ClampObjectAmplitudeProps),
         'limit_probe_support': ('phaser.engines.common.regularizers:LimitProbeSupport', LimitProbeSupportProps),
         'layers': ('phaser.engines.common.regularizers:RegularizeLayers', RegularizeLayersProps),
+        'tilt': ('phaser.engines.common.regularizers:RegularizeTilt', RegularizeTiltProps),
         'obj_low_pass': ('phaser.engines.common.regularizers:ObjLowPass', ObjLowPassProps),
         'obj_gaussian': ('phaser.engines.common.regularizers:ObjGaussian', GaussianProps),
         'remove_phase_ramp': ('phaser.engines.common.regularizers:RemovePhaseRamp', t.Dict[str, t.Any]),


### PR DESCRIPTION
added tilt regularizer, smooth by gaussian with std in the units of angstrom, 1A seems to reasonably remove the atomic contrast in tilt. But the implementation is kinda slow. 5s for 256*256 scan positions. Alternatively, needs to keep scan/tilt as 2D, probably not what you wanted