### PR TITLE
Postiv phase and example yaml

### DIFF
--- a/examples/czo_grad.yaml
+++ b/examples/czo_grad.yaml
@@ -67,7 +67,7 @@ engines:
      - type: clamp_object_amplitude
        amplitude: 1.05
      - type: nonneg_object_phase
-       relax: 0
+       weight: 1.0
 
    update_probe: {after: 5}
    update_positions: {after: 5}
@@ -129,6 +129,8 @@ engines:
      - type: tilt_gaussian
        sigma: 5.0
        weight: 0.1
+     - type: nonneg_object_phase
+       weight: 1.0
 
    update_probe: True
    update_positions: True
@@ -187,7 +189,7 @@ engines:
      - type: clamp_object_amplitude
        amplitude: 1.05
      - type: nonneg_object_phase
-       relax: 0
+       weight: 1.0
      - type: tilt_gaussian
        sigma: 5.0 # real Å
        weight: 0.3

--- a/examples/czo_grad.yaml
+++ b/examples/czo_grad.yaml
@@ -1,0 +1,209 @@
+---
+name: "acq1_09_postiv"
+backend: jax
+
+# raw data source
+# test
+raw_data:
+  type: empad
+  path: "./acq1_of13/acq1_of13_calib.json"
+
+
+init:
+  tilt:
+    type: custom
+    path: './acq1_of13/tilt_scan_x150_y300.npy'
+
+post_init:
+ - drop_nans
+ - diffraction_align
+
+# initialization
+
+slices:
+  n: 50
+  total_thickness: 190
+
+engines:
+#0 high reg basic and late start high position update
+ - type: 'gradient'
+   sim_shape: [128, 128]
+   probe_modes: 8
+   niter: 100
+   grouping: 128
+   bwlim_frac: 1.0
+
+   noise_model:
+     type: 'poisson'
+     eps: 2.0
+
+   solvers:
+     object:
+       type: 'adam'
+       learning_rate: 5.0e-3
+       nesterov: True
+     probe:
+       type: 'adam'
+       learning_rate: 0.01 # lower down from 0.05
+       nesterov: True
+     positions:
+       type: 'adam'
+       learning_rate: 0.05 # cannot go too high
+       nesterov: True
+
+   regularizers:
+     - type: obj_l2
+       cost: 0.2
+     - type: obj_tikh
+       cost: 0.4
+
+   group_constraints: []
+   iter_constraints:
+     - type: layers
+       sigma: 10
+       weight: 0.9
+     - type: limit_probe_support
+       max_angle: 28.0
+     - type: clamp_object_amplitude
+       amplitude: 1.05
+     - type: nonneg_object_phase
+       relax: 0
+
+   update_probe: {after: 5}
+   update_positions: {after: 5}
+
+   save: {every: 10}
+   save_images: {every: 5}
+   save_options:
+     images: [
+      'probe', 'probe_recip', 'object_phase_sum', 'object_mag_sum',
+      'object_phase_stack', 'object_mag_stack', 'scan',
+     ]
+   early_termination: 5
+
+#1 late start tilt
+ - type: 'gradient'
+   sim_shape: [128, 128]
+   probe_modes: 8
+   niter: 100
+   grouping: 128
+   bwlim_frac: 1.0
+
+   noise_model:
+     type: 'poisson'
+     eps: 2.0
+
+   solvers:
+     object:
+       type: 'adam'
+       learning_rate: 5.0e-3
+       nesterov: True
+     probe:
+       type: 'adam'
+       learning_rate: 5.0e-3
+       nesterov: True
+     positions:
+       type: 'adam'
+       learning_rate: 5.0e-3
+       nesterov: True
+     tilt:
+       type: 'adam'
+       learning_rate: 0.05
+       nesterov: True
+
+   regularizers:
+     - type: obj_l2
+       cost: 0.2
+     - type: obj_tikh
+       cost: 0.4
+
+   group_constraints: []
+   iter_constraints:
+     - type: layers
+       sigma: 10
+       weight: 0.9
+     - type: limit_probe_support
+       max_angle: 28.0
+     - type: clamp_object_amplitude
+       amplitude: 1.05
+     - type: tilt_gaussian
+       sigma: 5.0
+       weight: 0.1
+
+   update_probe: True
+   update_positions: True
+   update_tilt: True
+
+   save: {every: 10}
+   save_images: {every: 5}
+   save_options:
+     images: [
+      'probe', 'probe_recip', 'object_phase_sum', 'object_mag_sum',
+      'object_phase_stack', 'object_mag_stack', 'scan', 'tilt'
+     ]
+   early_termination: 5
+
+
+# relax layer constraint and pad
+ - type: 'gradient'
+   sim_shape: [192, 192] # enough up-sampling, 256 exceed mem limit
+   probe_modes: 8
+   niter: 100
+   grouping: 64 # 128 request 41 Gb mem,
+   bwlim_frac: 0.8 # but limit to ~2 alpha
+
+   noise_model:
+     type: 'poisson'
+     eps: 2.0
+
+   solvers:
+     object:
+       type: 'adam'
+       learning_rate: 1.5e-3
+       nesterov: True
+     probe:
+       type: 'adam'
+       learning_rate: 1.5e-3 # probe should be comparable with object
+       nesterov: True
+     positions:
+       type: 'adam'
+       learning_rate: 1.0e-3
+       nesterov: True
+     tilt:
+       type: 'adam'
+       learning_rate: 1.0e-3
+       nesterov: True
+
+   regularizers:
+     - type: obj_l2
+       cost: 0.2
+     - type: obj_tikh
+       cost: 0.4
+
+   group_constraints: []
+   iter_constraints:
+     - type: limit_probe_support
+       max_angle: 28.0
+     - type: clamp_object_amplitude
+       amplitude: 1.05
+     - type: nonneg_object_phase
+       relax: 0
+     - type: tilt_gaussian
+       sigma: 5.0 # real Å
+       weight: 0.3
+     - type: layers
+       sigma: 4.0
+       weight: 0.6
+
+   update_probe: {after: 5}
+   update_positions: {after: 5}
+   update_tilt: {after: 5}
+
+   save: {every: 5}
+   save_images: {every: 5}
+   save_options:
+     images: [
+      'probe', 'probe_recip', 'object_phase_sum', 'object_mag_sum',
+      'object_phase_stack', 'object_mag_stack', 'scan', 'tilt'
+     ]
+   early_termination: 15

--- a/phaser/engines/common/regularizers.py
+++ b/phaser/engines/common/regularizers.py
@@ -11,7 +11,7 @@ from phaser.utils.num import (
 )
 from phaser.state import ReconsState
 from phaser.hooks.regularization import (
-    ClampObjectAmplitudeProps, LimitProbeSupportProps,
+    ClampObjectAmplitudeProps, LimitProbeSupportProps, NonNegObjectPhaseProps,
     RegularizeLayersProps, ObjLowPassProps, GaussianProps,
     CostRegularizerProps, TVRegularizerProps, UnstructuredGaussianProps
 )
@@ -81,6 +81,31 @@ class RemovePhaseRamp:
         phase = remove_linear_ramp(xp.angle(sim.object.data), state)
         sim.object.data = t.cast(NDArray[numpy.complexfloating], xp.abs(sim.object.data) * xp.exp(1.j * phase))
         return (sim, state)
+
+
+
+@partial(jit, donate_argnames=('obj',), cupy_fuse=True)
+def non_neg_phase(obj: NDArray[numpy.complexfloating], relax:  t.Union[float, numpy.floating]) -> NDArray[numpy.complexfloating]:
+    xp = get_array_module(obj)
+    obj_phase = xp.angle(obj)
+    obj_phase = (1 - relax) * xp.maximum(obj_phase, 0) + relax * obj_phase
+
+    return xp.abs(obj) * xp.exp(1j * obj_phase)
+
+
+class NonNegObjectPhase:
+    def __init__(self, args: None, props: NonNegObjectPhaseProps):
+        self.relax: float = props.relax
+
+    def init_state(self, sim: ReconsState) -> None:
+        return None
+
+    def apply_group(self, group: NDArray[numpy.integer], sim: ReconsState, state: None) -> t.Tuple[ReconsState, None]:
+        return self.apply_iter(sim, state)
+
+    def apply_iter(self, sim: ReconsState, state: None) -> t.Tuple[ReconsState, None]:
+        sim.object.data = non_neg_phase(sim.object.data, self.relax)
+        return (sim, None)
 
 
 class RegularizeLayers:

--- a/phaser/engines/common/regularizers.py
+++ b/phaser/engines/common/regularizers.py
@@ -85,17 +85,20 @@ class RemovePhaseRamp:
 
 
 @partial(jit, donate_argnames=('obj',), cupy_fuse=True)
-def non_neg_phase(obj: NDArray[numpy.complexfloating], relax:  t.Union[float, numpy.floating]) -> NDArray[numpy.complexfloating]:
+def non_neg_phase(obj: NDArray[numpy.complexfloating], weight: t.Union[float, numpy.floating]) -> NDArray[numpy.complexfloating]:
+    """
+    weight: between 0-1
+    """
     xp = get_array_module(obj)
     obj_phase = xp.angle(obj)
-    obj_phase = (1 - relax) * xp.maximum(obj_phase, 0) + relax * obj_phase
+    obj_phase = weight * xp.maximum(obj_phase, 0) + (1-weight) * obj_phase
 
     return xp.abs(obj) * xp.exp(1j * obj_phase)
 
 
 class NonNegObjectPhase:
     def __init__(self, args: None, props: NonNegObjectPhaseProps):
-        self.relax: float = props.relax
+        self.weight: float = props.weight
 
     def init_state(self, sim: ReconsState) -> None:
         return None
@@ -104,7 +107,7 @@ class NonNegObjectPhase:
         return self.apply_iter(sim, state)
 
     def apply_iter(self, sim: ReconsState, state: None) -> t.Tuple[ReconsState, None]:
-        sim.object.data = non_neg_phase(sim.object.data, self.relax)
+        sim.object.data = non_neg_phase(sim.object.data, self.weight)
         return (sim, None)
 
 

--- a/phaser/hooks/regularization.py
+++ b/phaser/hooks/regularization.py
@@ -69,7 +69,7 @@ class GaussianProps(Dataclass):
 
 
 class NonNegObjectPhaseProps(Dataclass):
-    relax: float = 0.0
+    weight: float = 1.0
 
 
 class IterConstraintHook(Hook[None, IterConstraint]):

--- a/phaser/hooks/regularization.py
+++ b/phaser/hooks/regularization.py
@@ -68,6 +68,10 @@ class GaussianProps(Dataclass):
     weight: float = 0.9
 
 
+class NonNegObjectPhaseProps(Dataclass):
+    relax: float = 0.0
+
+
 class IterConstraintHook(Hook[None, IterConstraint]):
     known = {
         'clamp_object_amplitude': ('phaser.engines.common.regularizers:ClampObjectAmplitude', ClampObjectAmplitudeProps),
@@ -78,6 +82,8 @@ class IterConstraintHook(Hook[None, IterConstraint]):
         'opr_gaussian': ('phaser.engines.common.regularizers:UnstructuredGaussian', OPRGaussianProps),
         'tilt_gaussian': ('phaser.engines.common.regularizers:UnstructuredGaussian', TiltGaussianProps),
         'remove_phase_ramp': ('phaser.engines.common.regularizers:RemovePhaseRamp', t.Dict[str, t.Any]),
+        'nonneg_object_phase': ('phaser.engines.common.regularizers:NonNegObjectPhase', NonNegObjectPhaseProps),
+
     }
 
 
@@ -88,6 +94,8 @@ class GroupConstraintHook(Hook[None, GroupConstraint]):
         'obj_low_pass': ('phaser.engines.common.regularizers:ObjLowPass', ObjLowPassProps),
         'obj_gaussian': ('phaser.engines.common.regularizers:ObjGaussian', GaussianProps),
         'remove_phase_ramp': ('phaser.engines.common.regularizers:RemovePhaseRamp', t.Dict[str, t.Any]),
+        'nonneg_object_phase': ('phaser.engines.common.regularizers:NonNegObjectPhase', NonNegObjectPhaseProps),
+
     }
 
 


### PR DESCRIPTION
Added NonNegObjectPhase constraint to clip negative object phase values, together with a recent YAML file added in the examples that uses `nonneg_object_phase`  iter_constraint. 

Test and comparison figure 1:
<img width="569" height="249" alt="image" src="https://github.com/user-attachments/assets/b4ef7fd8-7572-440c-a984-301178271ba6" />

figure 2:

<img width="568" height="419" alt="image" src="https://github.com/user-attachments/assets/d2c08fa8-aeb7-41d0-bc8c-6e194a57afec" />
